### PR TITLE
Explicit support to generate doc and tag

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -15,3 +15,13 @@ override_dh_auto_configure:
 
 override_dh_strip:
 	dh_strip -a --dbg-package=libgz-plugin3-dbg
+
+# Execute doc creation to export at least the doxygen tag file
+override_dh_auto_build:
+	dh_auto_build -- doc
+	dh_auto_build
+
+override_dh_auto_install:
+	dh_auto_install
+	install -d debian/tmp/usr/share/gz/gz-plugin3/
+	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-plugin3/


### PR DESCRIPTION
Deprecate #3 and include the doc call and installation.